### PR TITLE
Adopted link to forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ development and community news:
 - Follow us on [Twitter] and [Facebook].
 - Subscribe to the [Mixxx Development Blog][blog].
 - Join the developer [mailing list].
-- Post on the [Mixxx forums][forums].
+- Post on the [Mixxx discord channel][discord].
+- Archive of the [Mixxx forums][forums].
 
 ## License
 
@@ -109,3 +110,4 @@ license.
 [Mixxx glossary]: https://www.transifex.com/projects/p/mixxxdj/glossary/l/en/
 [hardware compatibility]: https://mixxx.org/wiki/doku.php/hardware_compatibility
 [zulip]: https://mixxx.zulipchat.com/
+[discord]: https://mixxx.discourse.group/


### PR DESCRIPTION
The switch to discord was not made public thus the REEADME should be updates accordingly, especially as it was not directly obvious that the phpBB forum was no longer the 1st place for forum communication.